### PR TITLE
Get GHC from haskell.org and go to lts-10.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ## Dockerfile for a haskell environment
 FROM       debian:stretch
 
-ARG GHC_VERSION
 ARG STACK_VERSION
 ARG LTS_VERSION
 
@@ -9,40 +8,26 @@ ARG LTS_VERSION
 ENV LANG            C.UTF-8
 
 RUN apt-get update && \
-    apt-get install -y curl ca-certificates clang make libgmp-dev gnupg2 xz-utils && \
-# fetch ghc and stack, along with the gpg sigs
-    curl -fSL https://downloads.haskell.org/~ghc/$GHC_VERSION/ghc-$GHC_VERSION-x86_64-deb8-linux.tar.xz -o ghc.tar.xz && \
-    curl -fSL https://downloads.haskell.org/~ghc/$GHC_VERSION/ghc-$GHC_VERSION-x86_64-deb8-linux.tar.xz.sig -o ghc.tar.xz.sig && \
+    apt-get install -y curl gnupg2 ca-certificates g++ libgmp-dev libncurses-dev make xz-utils && \
+# fetch stack and the gpg sig
     curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz -o stack.tar.gz && \
     curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz.asc -o stack.tar.gz.asc && \
 # setup gpg and get keys
     export GNUPGHOME="$(mktemp -d)" && \
-    gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys 97DB64AD && \
     gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
-# verify both ghc and stack signatures
-    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz && \
+# verify stack signature
     gpg --batch --verify stack.tar.gz.asc stack.tar.gz && \
 # we're done with curl and gnupg2 so purge them
     apt-get purge -y --auto-remove curl gnupg2 && \
-# extract ghc and install it
-    mkdir /root/ghc && \
-    tar -xf ghc.tar.xz -C /root/ghc --strip-components=1 && \
-    cd /root/ghc && \
-    ./configure && \
-    make install && \
-    cd - && \
 # extract stack and install it
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
-    stack config set system-ghc --global true && \
 # cleanup after ourselves and trim the image some
-    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz /ghc.tar.xz.sig /ghc.tar.xz /root/ghc /usr/share/doc/* /usr/share/man/* /usr/local/share/doc/* /usr/local/share/man/* && \
+    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz /usr/share/doc/* /usr/share/man/* /usr/local/share/doc/* /usr/local/share/man/* && \
     apt-get clean
 
 ENV PATH /root/.local/bin:$PATH
-
 ENV STACK_ROOT=/stack-root
-
-RUN stack config set system-ghc --global true && \
+RUN stack --resolver lts-$LTS_VERSION setup && \
     stack --resolver lts-$LTS_VERSION install stylish-haskell hlint intero
 
 VOLUME /stack-root

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,40 +3,49 @@ FROM       debian:stretch
 
 ARG GHC_VERSION
 ARG STACK_VERSION
-ARG CABAL_VERSION
-ARG HAPPY_VERSION
-ARG ALEX_VERSION
 ARG LTS_VERSION
 
 ## ensure locale is set during build
 ENV LANG            C.UTF-8
 
 RUN apt-get update && \
-    apt-get install -y gnupg2 procps && \
-    echo 'deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main' > /etc/apt/sources.list.d/ghc.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F6F88286 && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends cabal-install-$CABAL_VERSION ghc-$GHC_VERSION happy-$HAPPY_VERSION alex-$ALEX_VERSION \
-            zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev ca-certificates g++ git curl && \
+    apt-get install -y curl ca-certificates clang make libgmp-dev gnupg2 xz-utils && \
+# fetch ghc and stack, along with the gpg sigs
+    curl -fSL https://downloads.haskell.org/~ghc/$GHC_VERSION/ghc-$GHC_VERSION-x86_64-deb8-linux.tar.xz -o ghc.tar.xz && \
+    curl -fSL https://downloads.haskell.org/~ghc/$GHC_VERSION/ghc-$GHC_VERSION-x86_64-deb8-linux.tar.xz.sig -o ghc.tar.xz.sig && \
     curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz -o stack.tar.gz && \
     curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz.asc -o stack.tar.gz.asc && \
-    apt-get purge -y --auto-remove curl && \
-    apt-get clean && \
+# setup gpg and get keys
     export GNUPGHOME="$(mktemp -d)" && \
+    gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys 97DB64AD && \
     gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
+# verify both ghc and stack signatures
+    gpg --batch --verify ghc.tar.xz.sig ghc.tar.xz && \
     gpg --batch --verify stack.tar.gz.asc stack.tar.gz && \
+# we're done with curl and gnupg2 so purge them
+    apt-get purge -y --auto-remove curl gnupg2 && \
+# extract ghc and install it
+    mkdir /root/ghc && \
+    tar -xf ghc.tar.xz -C /root/ghc --strip-components=1 && \
+    cd /root/ghc && \
+    ./configure && \
+    make install && \
+    cd - && \
+# extract stack and install it
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
-    /usr/local/bin/stack config set system-ghc --global true && \
-    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz
+    stack config set system-ghc --global true && \
+# cleanup after ourselves and trim the image some
+    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz /ghc.tar.xz.sig /ghc.tar.xz /root/ghc /usr/share/doc/* /usr/share/man/* /usr/local/share/doc/* /usr/local/share/man/* && \
+    apt-get clean
 
-ENV PATH /root/.cabal/bin:/root/.local/bin:/opt/cabal/$CABAL_VERSION/bin:/opt/ghc/$GHC_VERSION/bin:/opt/happy/$HAPPY_VERSION/bin:/opt/alex/$ALEX_VERSION/bin:$PATH
+ENV PATH /root/.local/bin:$PATH
 
 ENV STACK_ROOT=/stack-root
 
 RUN stack config set system-ghc --global true && \
-    stack --resolver lts-$LTS_VERSION install stylish-haskell hlint
+    stack --resolver lts-$LTS_VERSION install stylish-haskell hlint intero
 
 VOLUME /stack-root
 
 ## run ghci by default unless a command is specified
-CMD ["ghci"]
+CMD ["stack", "ghci"]

--- a/build
+++ b/build
@@ -3,9 +3,6 @@
 docker build \
   --build-arg GHC_VERSION=8.2.2 \
   --build-arg STACK_VERSION=1.6.5 \
-  --build-arg CABAL_VERSION=2.0 \
-  --build-arg HAPPY_VERSION=1.19.5 \
-  --build-arg ALEX_VERSION=3.1.7 \
-  --build-arg LTS_VERSION=10.6 \
-  -t flipstone/stack-lts:10.6 \
+  --build-arg LTS_VERSION=10.7 \
+  -t flipstone/stack-lts:v1-10.7 \
   .

--- a/build
+++ b/build
@@ -1,8 +1,12 @@
 #!/bin/sh
 
+STACK_VERSION=1.6.5
+LTS_VERSION=10.7
+
+INTERNAL_VERSION=1
+
 docker build \
-  --build-arg GHC_VERSION=8.2.2 \
-  --build-arg STACK_VERSION=1.6.5 \
-  --build-arg LTS_VERSION=10.7 \
-  -t flipstone/stack-lts:v1-10.7 \
+  --build-arg STACK_VERSION=$STACK_VERSION \
+  --build-arg LTS_VERSION=$LTS_VERSION \
+  -t flipstone/stack-lts:v$INTERNAL_VERSION-$LTS_VERSION-$STACK_VERSION \
   .


### PR DESCRIPTION
- Fetches ghc directly from haskell.org
- Switches to new vX-LTS versioning scheme
- Does not need to explicitly install alex/happy/cabal so no more keeping those versions around