### PR TITLE
Add stack 1.9.3 to v2 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 | 2018-03-12 | v1            | 1.6.5              |
 | 2018-05-23 | v2            | 1.7.1              |
 | 2018-10-10 | v2            | 1.9.0.1-prerelease |
+| 2018-12-20 | v2            | 1.9.3              |
+
 
 ## Versioning
 When making updates to this repo, if the contents of the docker image, besides the stack version, change, the image version should be updated.  The stack version within a particular docker image, does not necessitate an image version bump.  Additionally, any particular stack version could be used within multiple image versions.

--- a/v2/1.9.3/Dockerfile
+++ b/v2/1.9.3/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz.asc -o stack.tar.gz.asc && \
 # setup gpg and get keys
     export GNUPGHOME="$(mktemp -d)" && \
-    gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
+    gpg --batch --keyserver ipv4.pool.sks-keyservers.net --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
 # verify stack signature
     gpg --batch --verify stack.tar.gz.asc stack.tar.gz && \
 # we're done with curl and gnupg2 so purge them

--- a/v2/1.9.3/Dockerfile
+++ b/v2/1.9.3/Dockerfile
@@ -1,0 +1,30 @@
+## Dockerfile for a haskell environment
+FROM       debian:stretch-20180312
+
+ENV STACK_VERSION 1.9.3
+
+## ensure locale is set during build
+ENV LANG            C.UTF-8
+
+RUN apt-get update && \
+    apt-get install -y procps curl gnupg2 ca-certificates g++ libgmp-dev libncurses-dev make xz-utils git zlib1g-dev && \
+# fetch stack and the gpg sig
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz -o stack.tar.gz && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz.asc -o stack.tar.gz.asc && \
+# setup gpg and get keys
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
+# verify stack signature
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz && \
+# we're done with curl and gnupg2 so purge them
+    apt-get purge -y --auto-remove curl gnupg2 && \
+# extract stack and install it
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
+# cleanup after ourselves and trim the image some
+    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz /usr/share/doc/* /usr/share/man/* /usr/local/share/doc/* /usr/local/share/man/* && \
+    apt-get clean
+
+ENV PATH /root/.local/bin:$PATH
+ENV STACK_ROOT=/stack-root
+
+CMD ["stack"]


### PR DESCRIPTION
A version of the v2 image with stack 1.9.3 has been added,
and the README has been updated to reflect this as well.