### PR TITLE
Adds 2.1.0.3-rc as a v2 option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | 2018-05-23 | v2            | 1.7.1              |
 | 2018-10-10 | v2            | 1.9.0.1-prerelease |
 | 2018-12-20 | v2            | 1.9.3              |
-| 2019-05-28 | v2            | 2.1.0.1-rc         |
+| 2019-05-28 | v2            | 2.1.0.3-rc         |
 
 ## Versioning
 When making updates to this repo, if the contents of the docker image, besides the stack version, change, the image version should be updated.  The stack version within a particular docker image, does not necessitate an image version bump.  Additionally, any particular stack version could be used within multiple image versions.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | 2018-05-23 | v2            | 1.7.1              |
 | 2018-10-10 | v2            | 1.9.0.1-prerelease |
 | 2018-12-20 | v2            | 1.9.3              |
-
+| 2019-05-28 | v2            | 2.1.0.1-rc         |
 
 ## Versioning
 When making updates to this repo, if the contents of the docker image, besides the stack version, change, the image version should be updated.  The stack version within a particular docker image, does not necessitate an image version bump.  Additionally, any particular stack version could be used within multiple image versions.

--- a/v2/2.1.0.1-rc/Dockerfile
+++ b/v2/2.1.0.1-rc/Dockerfile
@@ -1,0 +1,31 @@
+## Dockerfile for a haskell environment
+FROM       debian:stretch-20180312
+
+ENV STACK_VERSION 2.1.0.1
+
+## ensure locale is set during build
+ENV LANG            C.UTF-8
+
+RUN apt-get update && \
+    apt-get install -y procps curl ca-certificates g++ libgmp-dev libncurses-dev make xz-utils git zlib1g-dev && \
+    #apt-get install -y procps curl gnupg2 ca-certificates g++ libgmp-dev libncurses-dev make xz-utils git zlib1g-dev && \
+# fetch stack and the gpg sig
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz -o stack.tar.gz && \
+    #curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz.asc -o stack.tar.gz.asc && \
+# setup gpg and get keys
+    #export GNUPGHOME="$(mktemp -d)" && \
+    #gpg --batch --keyserver ipv4.pool.sks-keyservers.net --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
+# verify stack signature
+    #gpg --batch --verify stack.tar.gz.asc stack.tar.gz && \
+# we're done with curl and gnupg2 so purge them
+    apt-get purge -y --auto-remove curl && \
+# extract stack and install it
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
+# cleanup after ourselves and trim the image some
+    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz /usr/share/doc/* /usr/share/man/* /usr/local/share/doc/* /usr/local/share/man/* && \
+    apt-get clean
+
+ENV PATH /root/.local/bin:$PATH
+ENV STACK_ROOT=/stack-root
+
+CMD ["stack"]

--- a/v2/2.1.0.1-rc/Dockerfile
+++ b/v2/2.1.0.1-rc/Dockerfile
@@ -8,16 +8,11 @@ ENV LANG            C.UTF-8
 
 RUN apt-get update && \
     apt-get install -y procps curl ca-certificates g++ libgmp-dev libncurses-dev make xz-utils git zlib1g-dev && \
-    #apt-get install -y procps curl gnupg2 ca-certificates g++ libgmp-dev libncurses-dev make xz-utils git zlib1g-dev && \
-# fetch stack and the gpg sig
     curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz -o stack.tar.gz && \
-    #curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz.asc -o stack.tar.gz.asc && \
-# setup gpg and get keys
-    #export GNUPGHOME="$(mktemp -d)" && \
-    #gpg --batch --keyserver ipv4.pool.sks-keyservers.net --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
-# verify stack signature
-    #gpg --batch --verify stack.tar.gz.asc stack.tar.gz && \
-# we're done with curl and gnupg2 so purge them
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz.sha256 -o stack.tar.gz.sha256 && \
+# verify download checksum (asc files for 2.1.0.1 were not published, so no gpg verification is possible)
+    echo `cat stack.tar.gz.sha256` stack.tar.gz | sha256sum -c && \
+# we're done with curl so remove it
     apt-get purge -y --auto-remove curl && \
 # extract stack and install it
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \

--- a/v2/2.1.0.3-rc/Dockerfile
+++ b/v2/2.1.0.3-rc/Dockerfile
@@ -1,7 +1,7 @@
 ## Dockerfile for a haskell environment
 FROM       debian:stretch-20180312
 
-ENV STACK_VERSION 2.1.0.1
+ENV STACK_VERSION 2.1.0.3
 
 ## ensure locale is set during build
 ENV LANG            C.UTF-8
@@ -17,7 +17,7 @@ RUN apt-get update && \
 # extract stack and install it
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
 # cleanup after ourselves and trim the image some
-    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz /usr/share/doc/* /usr/share/man/* /usr/local/share/doc/* /usr/local/share/man/* && \
+    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.sha256 /stack.tar.gz /usr/share/doc/* /usr/share/man/* /usr/local/share/doc/* /usr/local/share/man/* && \
     apt-get clean
 
 ENV PATH /root/.local/bin:$PATH


### PR DESCRIPTION
A new version of stack has been made available, so a new
Dockerfile has been created to allow us to use it.

GPG verification of the stack download has been removed in this commit,
as there is currently no signature file available, and the SHA256
file is formatted incorrectly for automated tool usage.  Manual
verification of the SHA256 confirms that the download is correct.