### PR TITLE
Adds 2.1.1 as a V2 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 | 2018-10-10 | v2            | 1.9.0.1-prerelease |
 | 2018-12-20 | v2            | 1.9.3              |
 | 2019-05-28 | v2            | 2.1.0.3-rc         |
+| 2019-06-13 | v2            | 2.1.1              |
 
 ## Versioning
 When making updates to this repo, if the contents of the docker image, besides the stack version, change, the image version should be updated.  The stack version within a particular docker image, does not necessitate an image version bump.  Additionally, any particular stack version could be used within multiple image versions.

--- a/v2/2.1.1/Dockerfile
+++ b/v2/2.1.1/Dockerfile
@@ -1,0 +1,33 @@
+## Dockerfile for a haskell environment
+FROM       debian:stretch-20180312
+
+ENV STACK_VERSION 2.1.1
+
+## ensure locale is set during build
+ENV LANG            C.UTF-8
+
+RUN apt-get update && \
+    apt-get install -y procps curl gnupg2 ca-certificates g++ libgmp-dev libncurses-dev make xz-utils git zlib1g-dev && \
+# fetch stack and the gpg sig
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz -o stack.tar.gz && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz.asc -o stack.tar.gz.asc && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz.sha256 -o stack.tar.gz.sha256 && \
+# setup gpg and get keys
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver ipv4.pool.sks-keyservers.net --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 0x65101ff31c5c154d && \
+# verify stack signature
+    gpg --batch --verify stack.tar.gz.asc stack.tar.gz && \
+# verify download checksum
+    echo `cat stack.tar.gz.sha256` stack.tar.gz | sha256sum -c && \
+# we're done with curl and gnupg2 so remove them
+    apt-get purge -y --auto-remove curl gnupg2 && \
+# extract stack and install it
+    tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
+# cleanup after ourselves and trim the image some
+    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz.sha256 /stack.tar.gz /usr/share/doc/* /usr/share/man/* /usr/local/share/doc/* /usr/local/share/man/* && \
+    apt-get clean
+
+ENV PATH /root/.local/bin:$PATH
+ENV STACK_ROOT=/stack-root
+
+CMD ["stack"]


### PR DESCRIPTION
A new version of stack, v2.1.1, has been released.
This is now available as a V2 option.

Downloads are now signed with a developer's personal key,
which in turn should be signed by dev@fpcomplete.com.

I haven't found a good way yet to verify that the personal key is, in fact, signed by 
dev@fpcomplete.com (and additionally that it's not revoked).  We could use
`gpg --list-sigs` or `gpg --check-sigs` but each of those would require some more 
work to grep through the output for a specific signature, and then we would have to somehow
check to make sure that the signature hasn't been revoked.