### PR TITLE
[ch20123] Adds image for stack 2.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 | 2018-10-10 | v2            | 1.9.0.1-prerelease |
 | 2018-12-20 | v2            | 1.9.3              |
 | 2019-06-03 | v2            | 2.1.0.3-rc         |
+| 2021-02-02 | v3            | 2.5.1              |
 
 ## Versioning
 When making updates to this repo, if the contents of the docker image, besides the stack version, change, the image version should be updated.  The stack version within a particular docker image, does not necessitate an image version bump.  Additionally, any particular stack version could be used within multiple image versions.

--- a/v3/2.5.1/Dockerfile
+++ b/v3/2.5.1/Dockerfile
@@ -1,0 +1,26 @@
+## Dockerfile for a haskell environment
+FROM       debian:buster-20201209
+
+ENV STACK_VERSION 2.5.1
+
+## ensure locale is set during build
+ENV LANG            C.UTF-8
+
+RUN apt-get update && \
+    apt-get install -y procps curl ca-certificates g++ libgmp-dev libncurses-dev make xz-utils git zlib1g-dev && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64.tar.gz --remote-name && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64.tar.gz.sha256  --remote-name && \
+# verify download checksum (asc files for 2.1.0.1 were not published, so no gpg verification is possible)
+    sha256sum -c stack-$STACK_VERSION-linux-x86_64.tar.gz.sha256 && \
+# we're done with curl so remove it
+    apt-get purge -y --auto-remove curl && \
+# extract stack and install it
+    tar -xf stack-$STACK_VERSION-linux-x86_64.tar.gz -C /usr/local/bin --strip-components=1 && \
+# cleanup after ourselves and trim the image some
+    rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack-$STACK_VERSION-linux-x86_64.tar.gz.sha256 /stack-$STACK_VERSION-linux-x86_64.tar.gz /usr/share/doc/* /usr/share/man/* /usr/local/share/doc/* /usr/local/share/man/* && \
+    apt-get clean
+
+ENV PATH /root/.local/bin:$PATH
+ENV STACK_ROOT=/stack-root
+
+CMD ["stack"]


### PR DESCRIPTION
This necessitated a new Dockerfile version because the stack archive's
sha256sum now includes the filename so we couldn't write it to the
generic 'stack.tar.gz' file anymore.

I also decided to move us to the latest debian lts - buster